### PR TITLE
Corrects the bad location of the module for the test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ repositories {
 }
 
 dependencies {
-  compile "javax.mail:mail:$javamailVersion"
   vertxProvided("org.vert-x:vertx-core:$vertxVersion")
   vertxProvided("org.vert-x:vertx-platform:$vertxVersion")
 


### PR DESCRIPTION
In combination with an update to the vert.x Gradle Plugin, this build now correctly tests the local module.

run ./mk --refresh-dependencies clean test
